### PR TITLE
feat: Support SodaMusic Api

### DIFF
--- a/Lyricify.Lyrics.Demo/Program.cs
+++ b/Lyricify.Lyrics.Demo/Program.cs
@@ -106,7 +106,7 @@ namespace Lyricify.Lyrics.Demo
                 Artists = new() { "OneRepublic" },
                 DurationMs = 143264,
                 Title = "RUNAWAY",
-            }, Searchers.Searchers.Netease, Searchers.Helpers.CompareHelper.MatchType.Medium).Result;
+            }, Searchers.Searchers.SodaMusic, Searchers.Helpers.CompareHelper.MatchType.Medium).Result;
             Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(search, Newtonsoft.Json.Formatting.Indented));
 
             //var qqSearch = new Searchers.QQMusicSearcher();

--- a/Lyricify.Lyrics.Demo/Program.cs
+++ b/Lyricify.Lyrics.Demo/Program.cs
@@ -1,6 +1,5 @@
 ﻿using Lyricify.Lyrics.Helpers;
 using Lyricify.Lyrics.Models;
-using Lyricify.Lyrics.Searchers;
 
 namespace Lyricify.Lyrics.Demo
 {
@@ -11,7 +10,7 @@ namespace Lyricify.Lyrics.Demo
             // ParsersDemo();
             // GeneratorsDemo();
             // TypeDetectorDemo();
-            SearchDemo();
+            // SearchDemo();
         }
 
         static void ParsersDemo()
@@ -51,7 +50,7 @@ namespace Lyricify.Lyrics.Demo
 
             lyricsData = ParseHelper.ParseLyrics(File.ReadAllText("RawLyrics/SpotifyUnsyncedDemo.txt"), LyricsRawTypes.Spotify);
             Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(lyricsData, Newtonsoft.Json.Formatting.Indented));
-            
+
             lyricsData = ParseHelper.ParseLyrics(File.ReadAllText("RawLyrics/MusixmatchDemo.txt"), LyricsRawTypes.Musixmatch);
             Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(lyricsData, Newtonsoft.Json.Formatting.Indented));
             Helpers.Optimization.Musixmatch.StandardizeMusixmatchLyrics(lyricsData!.Lines!); // 优化 Musixmatch 歌词
@@ -107,12 +106,8 @@ namespace Lyricify.Lyrics.Demo
                 Artists = new() { "OneRepublic" },
                 DurationMs = 143264,
                 Title = "RUNAWAY",
-            }, Searchers.Searchers.SodaMusic, Searchers.Helpers.CompareHelper.MatchType.Medium).Result;
+            }, Searchers.Searchers.Netease, Searchers.Helpers.CompareHelper.MatchType.Medium).Result;
             Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(search, Newtonsoft.Json.Formatting.Indented));
-
-            var api = new Providers.Web.SodaMusic.Api();
-            var lyrics = api.GetLyric((search as SodaMusicSearchResult).Id).Result;
-            Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(lyrics, Newtonsoft.Json.Formatting.Indented));
 
             //var qqSearch = new Searchers.QQMusicSearcher();
             //var result = qqSearch.SearchForResult(new TrackMultiArtistMetadata()

--- a/Lyricify.Lyrics.Demo/Program.cs
+++ b/Lyricify.Lyrics.Demo/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Lyricify.Lyrics.Helpers;
 using Lyricify.Lyrics.Models;
+using Lyricify.Lyrics.Searchers;
 
 namespace Lyricify.Lyrics.Demo
 {
@@ -10,7 +11,7 @@ namespace Lyricify.Lyrics.Demo
             // ParsersDemo();
             // GeneratorsDemo();
             // TypeDetectorDemo();
-            // SearchDemo();
+            SearchDemo();
         }
 
         static void ParsersDemo()
@@ -108,6 +109,10 @@ namespace Lyricify.Lyrics.Demo
                 Title = "RUNAWAY",
             }, Searchers.Searchers.SodaMusic, Searchers.Helpers.CompareHelper.MatchType.Medium).Result;
             Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(search, Newtonsoft.Json.Formatting.Indented));
+
+            var api = new Providers.Web.SodaMusic.Api();
+            var lyrics = api.GetLyric((search as SodaMusicSearchResult).Id).Result;
+            Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(lyrics, Newtonsoft.Json.Formatting.Indented));
 
             //var qqSearch = new Searchers.QQMusicSearcher();
             //var result = qqSearch.SearchForResult(new TrackMultiArtistMetadata()

--- a/Lyricify.Lyrics.Helper/Helpers/ProviderHelper.cs
+++ b/Lyricify.Lyrics.Helper/Helpers/ProviderHelper.cs
@@ -12,5 +12,7 @@
         public static Providers.Web.Kugou.Api KugouApi => Providers.Web.Providers.KugouApi;
 
         public static Providers.Web.Musixmatch.Api MusixmatchApi => Providers.Web.Providers.MusixmatchApi;
+
+        public static Providers.Web.SodaMusic.Api SodaMusicApi => Providers.Web.Providers.SodaMusicApi;
     }
 }

--- a/Lyricify.Lyrics.Helper/Providers/Web/Providers.cs
+++ b/Lyricify.Lyrics.Helper/Providers/Web/Providers.cs
@@ -17,5 +17,9 @@
         private static Musixmatch.Api? _musixmatchApi;
 
         public static Musixmatch.Api MusixmatchApi => _musixmatchApi ??= new();
+
+        private static SodaMusic.Api? _sodaMusicApi;
+
+        public static SodaMusic.Api SodaMusicApi => _sodaMusicApi ??= new();
     }
 }

--- a/Lyricify.Lyrics.Helper/Providers/Web/SodaMusic/Api.cs
+++ b/Lyricify.Lyrics.Helper/Providers/Web/SodaMusic/Api.cs
@@ -1,11 +1,4 @@
-﻿using Lyricify.Lyrics.Decrypter.Qrc;
-using Lyricify.Lyrics.Helpers;
-using Lyricify.Lyrics.Models;
-using Lyricify.Lyrics.Providers.Web.QQMusic;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Newtonsoft.Json;
 
 namespace Lyricify.Lyrics.Providers.Web.SodaMusic
 {
@@ -43,41 +36,42 @@ namespace Lyricify.Lyrics.Providers.Web.SodaMusic
                 var resp = await PostAsync(url, data);
 
                 return resp.ToEntity<TrackDetailResult>();
-            } catch
+            }
+            catch
             {
                 return null;
             }
         }
 
-        public async Task<LyricResult?> GetLyric(string id)
-        {
-            var result = new LyricResult
-            {
-                Lyric = new LyricsData(),
-                Translate = new LyricsData(),
-            };
+        // 待后期歌词获取模块整理开源后并入
+        //public async Task<LyricResult?> GetLyric(string id)
+        //{
+        //    var result = new LyricResult
+        //    {
+        //        Lyric = new LyricsData(),
+        //        Translate = new LyricsData(),
+        //    };
 
-            var detail = await GetDetail(id);
-            // Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(detail, Newtonsoft.Json.Formatting.Indented));
+        //    var detail = await GetDetail(id);
+        //    // Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(detail, Newtonsoft.Json.Formatting.Indented));
 
-            var lyricDetail = detail?.Lyric;
-            if (lyricDetail != null)
-            {
-                Enum.TryParse(lyricDetail.Type, true, out LyricsRawTypes lyricType);
-                result.Lyric = ParseHelper.ParseLyrics(lyricDetail.Content, lyricType);
-                // Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(result.Lyric, Newtonsoft.Json.Formatting.Indented));
-            }
+        //    var lyricDetail = detail?.Lyric;
+        //    if (lyricDetail != null)
+        //    {
+        //        Enum.TryParse(lyricDetail.Type, true, out LyricsRawTypes lyricType);
+        //        result.Lyric = ParseHelper.ParseLyrics(lyricDetail.Content, lyricType);
+        //        // Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(result.Lyric, Newtonsoft.Json.Formatting.Indented));
+        //    }
 
-            if (lyricDetail.LangTranslations.ContainsKey("ZH-HANS-CN"))
-            {
-                var lyricTrans = lyricDetail.LangTranslations["ZH-HANS-CN"];
-                Enum.TryParse(lyricTrans.Type, true, out LyricsRawTypes lyricTransType);
-                result.Translate = ParseHelper.ParseLyrics(lyricTrans.Content, lyricTransType);
-                // Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(result.Translate, Newtonsoft.Json.Formatting.Indented));
-            }
+        //    if (lyricDetail.LangTranslations.ContainsKey("ZH-HANS-CN"))
+        //    {
+        //        var lyricTrans = lyricDetail.LangTranslations["ZH-HANS-CN"];
+        //        Enum.TryParse(lyricTrans.Type, true, out LyricsRawTypes lyricTransType);
+        //        result.Translate = ParseHelper.ParseLyrics(lyricTrans.Content, lyricTransType);
+        //        // Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(result.Translate, Newtonsoft.Json.Formatting.Indented));
+        //    }
 
-            return result;
-
-        }
+        //    return result;
+        //}
     }
 }

--- a/Lyricify.Lyrics.Helper/Providers/Web/SodaMusic/Api.cs
+++ b/Lyricify.Lyrics.Helper/Providers/Web/SodaMusic/Api.cs
@@ -1,4 +1,5 @@
-﻿using Lyricify.Lyrics.Helpers;
+﻿using Lyricify.Lyrics.Decrypter.Qrc;
+using Lyricify.Lyrics.Helpers;
 using Lyricify.Lyrics.Models;
 using Lyricify.Lyrics.Providers.Web.QQMusic;
 using Newtonsoft.Json;
@@ -50,22 +51,29 @@ namespace Lyricify.Lyrics.Providers.Web.SodaMusic
 
         public async Task<LyricResult?> GetLyric(string id)
         {
-            var result = new LyricResult();
+            var result = new LyricResult
+            {
+                Lyric = new LyricsData(),
+                Translate = new LyricsData(),
+            };
 
             var detail = await GetDetail(id);
+            // Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(detail, Newtonsoft.Json.Formatting.Indented));
 
             var lyricDetail = detail?.Lyric;
             if (lyricDetail != null)
             {
-                Enum.TryParse(lyricDetail.Type, out LyricsRawTypes lyricType);
+                Enum.TryParse(lyricDetail.Type, true, out LyricsRawTypes lyricType);
                 result.Lyric = ParseHelper.ParseLyrics(lyricDetail.Content, lyricType);
+                // Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(result.Lyric, Newtonsoft.Json.Formatting.Indented));
             }
 
             if (lyricDetail.LangTranslations.ContainsKey("ZH-HANS-CN"))
             {
                 var lyricTrans = lyricDetail.LangTranslations["ZH-HANS-CN"];
-                Enum.TryParse(lyricTrans.Type, out LyricsRawTypes lyricTransType);
+                Enum.TryParse(lyricTrans.Type, true, out LyricsRawTypes lyricTransType);
                 result.Translate = ParseHelper.ParseLyrics(lyricTrans.Content, lyricTransType);
+                // Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(result.Translate, Newtonsoft.Json.Formatting.Indented));
             }
 
             return result;

--- a/Lyricify.Lyrics.Helper/Providers/Web/SodaMusic/Api.cs
+++ b/Lyricify.Lyrics.Helper/Providers/Web/SodaMusic/Api.cs
@@ -1,0 +1,75 @@
+﻿using Lyricify.Lyrics.Helpers;
+using Lyricify.Lyrics.Models;
+using Lyricify.Lyrics.Providers.Web.QQMusic;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Lyricify.Lyrics.Providers.Web.SodaMusic
+{
+    public class Api : BaseApi
+    {
+        protected override string HttpRefer => "https://api.qishui.com/";
+
+        protected override Dictionary<string, string>? AdditionalHeaders => null;
+
+        public new const string UserAgent = "LunaPC/2.6.5(197449790)";
+
+        public async Task<SearchResult?> Search(string keyword)
+        {
+            // search/{类型} 已知有all, track
+            string url = $"https://api.qishui.com/luna/pc/search/track?aid=386088&app_name=&region=&geo_region=&os_region=&sim_region=&device_id=&cdid=&iid=&version_name=&version_code=&channel=&build_mode=&network_carrier=&ac=&tz_name=&resolution=&device_platform=&device_type=&os_version=&fp=&q={Uri.EscapeDataString(keyword)}&cursor=&search_id=&search_method=input&debug_params=&from_search_id=&search_scene=";
+
+            var res = await GetAsync(url);
+
+            return JsonConvert.DeserializeObject<SearchResult>(res);
+        }
+
+        public async Task<TrackDetailResult?> GetDetail(string id)
+        {
+            string url = $"https://api.qishui.com/luna/pc/track_v2";
+
+            var data = new Dictionary<string, string>
+            {
+                { "track_id", id },
+                { "media_type", "track" },
+                { "queue_type", "" },
+            };
+
+            try
+            {
+                var resp = await PostAsync(url, data);
+
+                return resp.ToEntity<TrackDetailResult>();
+            } catch
+            {
+                return null;
+            }
+        }
+
+        public async Task<LyricResult?> GetLyric(string id)
+        {
+            var result = new LyricResult();
+
+            var detail = await GetDetail(id);
+
+            var lyricDetail = detail?.Lyric;
+            if (lyricDetail != null)
+            {
+                Enum.TryParse(lyricDetail.Type, out LyricsRawTypes lyricType);
+                result.Lyric = ParseHelper.ParseLyrics(lyricDetail.Content, lyricType);
+            }
+
+            if (lyricDetail.LangTranslations.ContainsKey("ZH-HANS-CN"))
+            {
+                var lyricTrans = lyricDetail.LangTranslations["ZH-HANS-CN"];
+                Enum.TryParse(lyricTrans.Type, out LyricsRawTypes lyricTransType);
+                result.Translate = ParseHelper.ParseLyrics(lyricTrans.Content, lyricTransType);
+            }
+
+            return result;
+
+        }
+    }
+}

--- a/Lyricify.Lyrics.Helper/Providers/Web/SodaMusic/Response.cs
+++ b/Lyricify.Lyrics.Helper/Providers/Web/SodaMusic/Response.cs
@@ -1,8 +1,4 @@
-﻿using Lyricify.Lyrics.Models;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Newtonsoft.Json;
 
 #nullable disable
 namespace Lyricify.Lyrics.Providers.Web.SodaMusic
@@ -670,12 +666,5 @@ namespace Lyricify.Lyrics.Providers.Web.SodaMusic
 
         [JsonProperty("video_model_type")]
         public int? VideoModelType { get; set; }
-    }
-
-    public class LyricResult
-    {
-        public LyricsData? Lyric { get; set; }
-
-        public LyricsData? Translate { get; set; }
     }
 }

--- a/Lyricify.Lyrics.Helper/Providers/Web/SodaMusic/Response.cs
+++ b/Lyricify.Lyrics.Helper/Providers/Web/SodaMusic/Response.cs
@@ -1,0 +1,681 @@
+﻿using Lyricify.Lyrics.Models;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+#nullable disable
+namespace Lyricify.Lyrics.Providers.Web.SodaMusic
+{
+    /// <summary>
+    /// Soda Music 搜索（tracks）接口返回
+    /// 仅覆盖当前使用到的字段，未使用字段可按需扩展
+    /// </summary>
+    public class SearchResult
+    {
+        [JsonProperty("status_info")]
+        public StatusInfo StatusInfo { get; set; }
+
+        [JsonProperty("result_groups")]
+        public List<ResultGroup> ResultGroups { get; set; }
+
+        [JsonProperty("extra")]
+        public Extra Extra { get; set; }
+    }
+
+    public class StatusInfo
+    {
+        [JsonProperty("log_id")]
+        public string LogId { get; set; }
+
+        /// <summary>
+        /// unix 秒
+        /// </summary>
+        [JsonProperty("now")]
+        public long Now { get; set; }
+
+        /// <summary>
+        /// unix 毫秒
+        /// </summary>
+        [JsonProperty("now_ts_ms")]
+        public long NowTsMs { get; set; }
+    }
+
+    public class Extra
+    {
+        [JsonProperty("log_extra")]
+        public string LogExtra { get; set; }
+    }
+
+    public class ResultGroup
+    {
+        public string Id { get; set; }
+
+        [JsonProperty("next_cursor")]
+        public string NextCursor { get; set; }
+
+        [JsonProperty("has_more")]
+        public bool HasMore { get; set; }
+
+        public List<ResultGroupItem> Data { get; set; }
+
+        [JsonProperty("display_view_all")]
+        public bool? DisplayViewAll { get; set; }
+
+        [JsonProperty("display_title")]
+        public string DisplayTitle { get; set; }
+
+        public string Description { get; set; }
+    }
+
+    public class ResultGroupItem
+    {
+        public Meta Meta { get; set; }
+        public Entity Entity { get; set; }
+    }
+
+    public class Meta
+    {
+        [JsonProperty("item_type")]
+        public string ItemType { get; set; }
+    }
+
+    public class Entity
+    {
+        public TrackContainer Track { get; set; }
+    }
+
+    public class TrackContainer
+    {
+        public string Id { get; set; }
+
+        public Album Album { get; set; }
+
+        public List<Artist> Artists { get; set; }
+
+        /// <summary>
+        /// 时长(ms)
+        /// </summary>
+        public long Duration { get; set; }
+
+        public string Name { get; set; }
+
+        public Preview Preview { get; set; }
+
+        public State State { get; set; }
+
+        public Stats Stats { get; set; }
+
+        public string Vid { get; set; }
+
+        [JsonProperty("label_info")]
+        public LabelInfo LabelInfo { get; set; }
+
+        [JsonProperty("sim_id")]
+        public long? SimId { get; set; }
+
+        /// <summary>
+        /// 可选码率集合（文件级）
+        /// </summary>
+        [JsonProperty("bit_rates")]
+        public List<BitRateItem> BitRates { get; set; }
+
+        [JsonProperty("audition_info")]
+        public AuditionInfo AuditionInfo { get; set; }
+
+        [JsonProperty("song_maker_team")]
+        public SongMakerTeam SongMakerTeam { get; set; }
+
+        [JsonProperty("media_type")]
+        public string MediaType { get; set; }
+
+        public bool? Explicit { get; set; }
+
+        public Chorus Chorus { get; set; }
+
+        public Colors Colors { get; set; }
+
+        [JsonProperty("limited_free_info")]
+        public object LimitedFreeInfo { get; set; }
+
+        /// <summary>
+        /// 1: 有人声; 2: 伴奏/翻唱等
+        /// </summary>
+        public int? Vocal { get; set; }
+
+        [JsonProperty("lang_codes")]
+        public List<string> LangCodes { get; set; }
+
+        [JsonProperty("first_vocal")]
+        public Range FirstVocal { get; set; }
+
+        [JsonProperty("sharable_platforms")]
+        public List<string> SharablePlatforms { get; set; }
+
+        /// <summary>
+        /// 可播放区间（ms）
+        /// </summary>
+        [JsonProperty("playable_range")]
+        public Range PlayableRange { get; set; }
+
+        [JsonProperty("plug_status")]
+        public PlugStatus PlugStatus { get; set; }
+
+        public List<TagWrapper> Tags { get; set; }
+
+        public List<Fragment> Fragments { get; set; }
+    }
+
+    public class Album
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        /// <summary>
+        /// unix 秒
+        /// </summary>
+        [JsonProperty("release_date")]
+        public long ReleaseDate { get; set; }
+
+        [JsonProperty("url_cover")]
+        public UrlWithTemplate UrlCover { get; set; }
+
+        [JsonProperty("url_player_bg")]
+        public UrlWithTemplate UrlPlayerBg { get; set; }
+
+        [JsonProperty("cover_gradient_effect_color")]
+        public List<RgbColor> CoverGradientEffectColor { get; set; }
+
+        [JsonProperty("playing_wave_color")]
+        public RgbaColor PlayingWaveColor { get; set; }
+
+        [JsonProperty("paused_wave_color")]
+        public RgbaColor PausedWaveColor { get; set; }
+    }
+
+    public class UrlWithTemplate
+    {
+        public string Uri { get; set; }
+
+        public List<string> Urls { get; set; }
+
+        [JsonProperty("template")]
+        public string Template { get; set; }
+
+        [JsonProperty("template_prefix")]
+        public string TemplatePrefix { get; set; }
+    }
+
+    public class Artist
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        [JsonProperty("url_avatar")]
+        public UrlWithTemplate UrlAvatar { get; set; }
+
+        public State State { get; set; }
+
+        [JsonProperty("user_info")]
+        public ArtistUserInfo UserInfo { get; set; }
+
+        [JsonProperty("simple_display_name")]
+        public string SimpleDisplayName { get; set; }
+
+        [JsonProperty("user_artist_type")]
+        public int? UserArtistType { get; set; }
+    }
+
+    public class ArtistUserInfo
+    {
+        public string Id { get; set; }
+
+        public string Nickname { get; set; }
+
+        [JsonProperty("medium_avatar_url")]
+        public UrlsOnly MediumAvatarUrl { get; set; }
+
+        [JsonProperty("thumb_avatar_url")]
+        public UrlsOnly ThumbAvatarUrl { get; set; }
+
+        [JsonProperty("artist_id")]
+        public string ArtistId { get; set; }
+
+        public bool? Secret { get; set; }
+
+        [JsonProperty("test_tag")]
+        public int? TestTag { get; set; }
+
+        [JsonProperty("vip_stage")]
+        public string VipStage { get; set; }
+
+        [JsonProperty("is_vip")]
+        public bool? IsVip { get; set; }
+    }
+
+    public class UrlsOnly
+    {
+        public List<string> Urls { get; set; }
+
+        [JsonProperty("need_complete_url")]
+        public bool? NeedCompleteUrl { get; set; }
+    }
+
+    public class State
+    {
+        [JsonProperty("blocked_by_me")]
+        public bool? BlockedByMe { get; set; }
+    }
+
+    public class Preview
+    {
+        /// <summary>
+        /// 试听时长(ms) 或有时是固定 30047/29002
+        /// </summary>
+        public int? Duration { get; set; }
+
+        /// <summary>
+        /// 试听起点(ms)
+        /// </summary>
+        public int? Start { get; set; }
+
+        public string Vid { get; set; }
+
+        [JsonProperty("bit_rates")]
+        public List<BitRateItem> BitRates { get; set; }
+    }
+
+    public class BitRateItem
+    {
+        /// <summary>
+        /// 比特率（br），单位 bps
+        /// </summary>
+        public long Br { get; set; }
+
+        /// <summary>
+        /// 文件大小（字节）
+        /// </summary>
+        public long Size { get; set; }
+
+        /// <summary>
+        /// 质量标识：medium/higher/highest/lossless/spatial
+        /// </summary>
+        public string Quality { get; set; }
+    }
+
+    public class Stats
+    {
+        [JsonProperty("count_collected")]
+        public long? CountCollected { get; set; }
+
+        [JsonProperty("count_comment")]
+        public long? CountComment { get; set; }
+
+        [JsonProperty("count_shared")]
+        public long? CountShared { get; set; }
+    }
+
+    public class LabelInfo
+    {
+        [JsonProperty("only_vip_download")]
+        public bool? OnlyVipDownload { get; set; }
+
+        [JsonProperty("only_vip_playable")]
+        public bool? OnlyVipPlayable { get; set; }
+
+        [JsonProperty("quality_only_vip_can_download")]
+        public List<string> QualityOnlyVipCanDownload { get; set; }
+
+        [JsonProperty("quality_only_vip_can_play")]
+        public List<string> QualityOnlyVipCanPlay { get; set; }
+
+        [JsonProperty("is_original")]
+        public bool? IsOriginal { get; set; }
+
+        [JsonProperty("quality_map")]
+        public Dictionary<string, QualityDetailWrap> QualityMap { get; set; }
+    }
+
+    public class QualityDetailWrap
+    {
+        [JsonProperty("play_detail")]
+        public QualityDetail PlayDetail { get; set; }
+
+        [JsonProperty("download_detail")]
+        public QualityDetail DownloadDetail { get; set; }
+    }
+
+    public class QualityDetail
+    {
+        public string Condition { get; set; }
+
+        [JsonProperty("need_vip")]
+        public bool? NeedVip { get; set; }
+
+        [JsonProperty("need_purchase")]
+        public bool? NeedPurchase { get; set; }
+    }
+
+    public class AuditionInfo
+    {
+        public string Vid { get; set; }
+
+        [JsonProperty("start_time_ms")]
+        public int? StartTimeMs { get; set; }
+
+        [JsonProperty("duration_ms")]
+        public int? DurationMs { get; set; }
+    }
+
+    public class SongMakerTeam
+    {
+        public List<NameOnly> Composers { get; set; }
+        public List<NameOnly> Lyricists { get; set; }
+    }
+
+    public class NameOnly
+    {
+        public string Name { get; set; }
+    }
+
+    public class Chorus
+    {
+        /// <summary>
+        /// 开始(ms)
+        /// </summary>
+        public int? Start { get; set; }
+
+        /// <summary>
+        /// 时长(ms)
+        /// </summary>
+        public int? Duration { get; set; }
+    }
+
+    public class Colors
+    {
+        [JsonProperty("cover_gradient_effect_color")]
+        public List<RgbColor> CoverGradientEffectColor { get; set; }
+
+        [JsonProperty("normal_lyric_color")]
+        public RgbaColor NormalLyricColor { get; set; }
+
+        [JsonProperty("playing_lyric_color")]
+        public RgbaColor PlayingLyricColor { get; set; }
+
+        [JsonProperty("recommend_reason_background_color")]
+        public RgbaColor RecommendReasonBackgroundColor { get; set; }
+
+        [JsonProperty("featured_comment_tag_color")]
+        public RgbaColor FeaturedCommentTagColor { get; set; }
+
+        [JsonProperty("background_color")]
+        public RgbaColor BackgroundColor { get; set; }
+
+        [JsonProperty("playing_wave_color")]
+        public RgbaColor PlayingWaveColor { get; set; }
+
+        [JsonProperty("paused_wave_color")]
+        public RgbaColor PausedWaveColor { get; set; }
+
+        [JsonProperty("comment_share_additional_color")]
+        public RgbaColor CommentShareAdditionalColor { get; set; }
+
+        [JsonProperty("base_colors")]
+        public List<RgbColor> BaseColors { get; set; }
+
+        [JsonProperty("non_interactive_anchor_background")]
+        public RgbaColor NonInteractiveAnchorBackground { get; set; }
+    }
+
+    public class RgbColor
+    {
+        public string Rgb { get; set; }
+    }
+
+    public class RgbaColor : RgbColor
+    {
+        public string Alpha { get; set; }
+    }
+
+    public class Range
+    {
+        /// <summary>
+        /// 开始(ms)
+        /// </summary>
+        public int? Start { get; set; }
+
+        /// <summary>
+        /// 时长(ms)
+        /// </summary>
+        public int? Duration { get; set; }
+    }
+
+    public class PlugStatus
+    {
+        [JsonProperty("can_plug")]
+        public bool? CanPlug { get; set; }
+
+        [JsonProperty("is_plugged")]
+        public bool? IsPlugged { get; set; }
+    }
+
+    public class TagWrapper
+    {
+        public TagCategory Category { get; set; }
+
+        [JsonProperty("first_level_tag")]
+        public Tag FirstLevelTag { get; set; }
+
+        [JsonProperty("second_level_tag")]
+        public Tag SecondLevelTag { get; set; }
+    }
+
+    public class TagCategory
+    {
+        [JsonProperty("tag_id")]
+        public long TagId { get; set; }
+
+        [JsonProperty("tag_name")]
+        public string TagName { get; set; }
+    }
+
+    public class Tag
+    {
+        [JsonProperty("tag_id")]
+        public long TagId { get; set; }
+
+        [JsonProperty("tag_name")]
+        public string TagName { get; set; }
+    }
+
+    public class Fragment
+    {
+        public string Type { get; set; }
+
+        [JsonProperty("start_time")]
+        public int? StartTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public int? EndTime { get; set; }
+    }
+
+    /// <summary>
+    /// Soda Music track_v2 接口返回（获取乐曲具体信息）
+    /// </summary>
+    public class TrackDetailResult
+    {
+        [JsonProperty("status_info")]
+        public StatusInfo StatusInfo { get; set; }
+
+        public LyricInfo Lyric { get; set; }
+
+        public TrackInfo Track { get; set; }
+
+        [JsonProperty("track_player")]
+        public TrackPlayer TrackPlayer { get; set; }
+
+        [JsonProperty("risk_result")]
+        public int? RiskResult { get; set; }
+
+        [JsonProperty("expire_at")]
+        public long? ExpireAt { get; set; }
+    }
+
+    public class LyricInfo
+    {
+        public string Content { get; set; }
+
+        public string Lang { get; set; }
+
+        [JsonProperty("hide_request_lyrics")]
+        public bool? HideRequestLyrics { get; set; }
+
+        public string Type { get; set; }
+
+        [JsonProperty("lyric_contributor")]
+        public LyricContributor LyricContributor { get; set; }
+
+        public string Id { get; set; }
+
+        [JsonProperty("lang_translations")]
+        public Dictionary<string, LyricTranslation> LangTranslations { get; set; }
+    }
+
+    public class LyricContributor
+    {
+        [JsonProperty("filter_reason")]
+        public string FilterReason { get; set; }
+    }
+
+    public class LyricTranslation
+    {
+        public string Content { get; set; }
+
+        public string Lang { get; set; }
+
+        [JsonProperty("hide_request_lyrics")]
+        public bool? HideRequestLyrics { get; set; }
+
+        public string Type { get; set; }
+
+        [JsonProperty("lyric_contributor")]
+        public LyricContributor LyricContributor { get; set; }
+
+        public string Id { get; set; }
+    }
+
+    public class TrackInfo
+    {
+        public string Id { get; set; }
+
+        public Album Album { get; set; }
+
+        public List<Artist> Artists { get; set; }
+
+        /// <summary>
+        /// 时长(ms)
+        /// </summary>
+        public long Duration { get; set; }
+
+        public string Name { get; set; }
+
+        public Preview Preview { get; set; }
+
+        public State State { get; set; }
+
+        public Stats Stats { get; set; }
+
+        public string Vid { get; set; }
+
+        [JsonProperty("label_info")]
+        public LabelInfo LabelInfo { get; set; }
+
+        [JsonProperty("sim_id")]
+        public long? SimId { get; set; }
+
+        [JsonProperty("bit_rates")]
+        public List<BitRateItem> BitRates { get; set; }
+
+        [JsonProperty("audition_info")]
+        public AuditionInfo AuditionInfo { get; set; }
+
+        [JsonProperty("song_maker_team")]
+        public SongMakerTeam SongMakerTeam { get; set; }
+
+        [JsonProperty("media_type")]
+        public string MediaType { get; set; }
+
+        public Chorus Chorus { get; set; }
+
+        public Colors Colors { get; set; }
+
+        [JsonProperty("limited_free_info")]
+        public LimitedFreeInfo LimitedFreeInfo { get; set; }
+
+        public int? Vocal { get; set; }
+
+        [JsonProperty("lang_codes")]
+        public List<string> LangCodes { get; set; }
+
+        [JsonProperty("first_vocal")]
+        public Range FirstVocal { get; set; }
+
+        [JsonProperty("sharable_platforms")]
+        public List<string> SharablePlatforms { get; set; }
+
+        [JsonProperty("plug_status")]
+        public PlugStatus PlugStatus { get; set; }
+
+        public List<TagWrapper> Tags { get; set; }
+    }
+
+    public class LimitedFreeInfo
+    {
+        [JsonProperty("queue_types")]
+        public List<string> QueueTypes { get; set; }
+
+        [JsonProperty("expire_time")]
+        public long? ExpireTime { get; set; }
+
+        public string Sign { get; set; }
+
+        [JsonProperty("sign_version")]
+        public string SignVersion { get; set; }
+
+        [JsonProperty("limited_free_type")]
+        public string LimitedFreeType { get; set; }
+
+        [JsonProperty("rewind_prev_intercept_type")]
+        public string RewindPrevInterceptType { get; set; }
+
+        [JsonProperty("intercept_type")]
+        public string InterceptType { get; set; }
+    }
+
+    public class TrackPlayer
+    {
+        [JsonProperty("expire_at")]
+        public long? ExpireAt { get; set; }
+
+        [JsonProperty("media_id")]
+        public string MediaId { get; set; }
+
+        [JsonProperty("url_player_info")]
+        public string UrlPlayerInfo { get; set; }
+
+        [JsonProperty("video_model")]
+        public string VideoModel { get; set; }
+
+        [JsonProperty("video_model_type")]
+        public int? VideoModelType { get; set; }
+    }
+
+    public class LyricResult
+    {
+        public LyricsData? Lyric { get; set; }
+
+        public LyricsData? Translate { get; set; }
+    }
+}

--- a/Lyricify.Lyrics.Helper/Searchers/SearcherHelper.cs
+++ b/Lyricify.Lyrics.Helper/Searchers/SearcherHelper.cs
@@ -20,5 +20,9 @@
         private static MusixmatchSearcher? _musixmatchSearcher;
 
         public static MusixmatchSearcher MusixmatchSearcher => _musixmatchSearcher ??= new();
+
+        private static SodaMusicSearcher? _sodaMusicSearcher;
+
+        public static SodaMusicSearcher SodaMusicSearcher => _sodaMusicSearcher ??= new();
     }
 }

--- a/Lyricify.Lyrics.Helper/Searchers/Searchers.cs
+++ b/Lyricify.Lyrics.Helper/Searchers/Searchers.cs
@@ -9,5 +9,6 @@
         Netease,
         Kugou,
         Musixmatch,
+        SodaMusic,
     }
 }

--- a/Lyricify.Lyrics.Helper/Searchers/SearchersHelper.cs
+++ b/Lyricify.Lyrics.Helper/Searchers/SearchersHelper.cs
@@ -19,6 +19,7 @@
                 Searchers.Netease => SearcherHelper.NeteaseSearcher,
                 Searchers.Kugou => SearcherHelper.KugouSearcher,
                 Searchers.Musixmatch => SearcherHelper.MusixmatchSearcher,
+                Searchers.SodaMusic => SearcherHelper.SodaMusicSearcher,
                 _ => throw new NotImplementedException(),
             };
         }
@@ -37,6 +38,7 @@
                 Searchers.Netease => new NeteaseSearcher(),
                 Searchers.Kugou => new KugouSearcher(),
                 Searchers.Musixmatch => new MusixmatchSearcher(),
+                Searchers.SodaMusic => new SodaMusicSearcher(),
                 _ => throw new NotImplementedException(),
             };
         }
@@ -52,6 +54,7 @@
             if (searcher is NeteaseSearcher) return Searchers.Netease;
             if (searcher is KugouSearcher) return Searchers.Kugou;
             if (searcher is MusixmatchSearcher) return Searchers.Musixmatch;
+            if (searcher is SodaMusicSearcher) return Searchers.SodaMusic;
             return null;
         }
     }

--- a/Lyricify.Lyrics.Helper/Searchers/SodaMusicSearchResult.cs
+++ b/Lyricify.Lyrics.Helper/Searchers/SodaMusicSearchResult.cs
@@ -1,0 +1,47 @@
+﻿using Lyricify.Lyrics.Providers.Web.SodaMusic;
+using Lyricify.Lyrics.Searchers.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Lyricify.Lyrics.Searchers
+{
+    public class SodaMusicSearchResult : ISearchResult
+    {
+        public ISearcher Searcher => new SodaMusicSearcher();
+
+        public SodaMusicSearchResult(string title, string[] artists, string album, string[]? albumArtists, int durationMs, string id)
+        {
+            Title = title;
+            Artists = artists;
+            Album = album;
+            AlbumArtists = albumArtists;
+            DurationMs = durationMs;
+            Id = id;
+        }
+
+        public SodaMusicSearchResult(ResultGroupItem Track) : this(
+            Track.Entity.Track.Name,
+            Track.Entity.Track.Artists.Select(a => a.Name).ToArray(),
+            Track.Entity.Track.Album.Name,
+            null,
+            (int)Track.Entity.Track.Duration,
+            Track.Entity.Track.Id
+            )
+        { }
+
+        public string Title { get; }
+
+        public string[] Artists { get; }
+
+        public string Album { get; }
+
+        public string Id { get; }
+
+        public string[]? AlbumArtists { get; }
+
+        public int? DurationMs { get; }
+
+        public CompareHelper.MatchType? MatchType { get; set; }
+    }
+}

--- a/Lyricify.Lyrics.Helper/Searchers/SodaMusicSearchResult.cs
+++ b/Lyricify.Lyrics.Helper/Searchers/SodaMusicSearchResult.cs
@@ -1,8 +1,5 @@
 ﻿using Lyricify.Lyrics.Providers.Web.SodaMusic;
 using Lyricify.Lyrics.Searchers.Helpers;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Lyricify.Lyrics.Searchers
 {

--- a/Lyricify.Lyrics.Helper/Searchers/SodaMusicSearcher.cs
+++ b/Lyricify.Lyrics.Helper/Searchers/SodaMusicSearcher.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Lyricify.Lyrics.Searchers
+﻿namespace Lyricify.Lyrics.Searchers
 {
     public class SodaMusicSearcher : Searcher, ISearcher
     {

--- a/Lyricify.Lyrics.Helper/Searchers/SodaMusicSearcher.cs
+++ b/Lyricify.Lyrics.Helper/Searchers/SodaMusicSearcher.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Lyricify.Lyrics.Searchers
+{
+    public class SodaMusicSearcher : Searcher, ISearcher
+    {
+        public override string Name => "SodaMusic";
+
+        public override string DisplayName => "Soda Music";
+
+        public override Searchers SearcherType => Searchers.SodaMusic;
+
+        public override async Task<List<ISearchResult>?> SearchForResults(string searchString)
+        {
+            var search = new List<ISearchResult>();
+
+            try
+            {
+                var result = await Providers.Web.Providers.SodaMusicApi.Search(searchString);
+                var resultDataList = result?.ResultGroups[0]?.Data;
+                if (resultDataList == null) return null;
+                foreach (var resultData in resultDataList)
+                {
+                    if (resultData.Meta?.ItemType != "track") continue;
+                    search.Add(new SodaMusicSearchResult(resultData));
+                }
+            }
+            catch
+            {
+                return null;
+            }
+
+            return search;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   - 酷狗音乐
   - Spotify (暂不支持)
   - Musixmatch
+  - 汽水音乐
 - 歌词处理优化
   - Explicit 歌词处理及修复
   - YRC 歌词优化


### PR DESCRIPTION
初步实现汽水音乐API集成，包括搜索、获取详情和歌词功能。由于歌词接入demo调试不便，未能进行调试。 （（其实是自己用汽水音乐配Lyricify Lite有些歌的歌词提供商得网易云/QQ切着来难受 小搓一下